### PR TITLE
Update Accessibility contrast test to get better coverage

### DIFF
--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -305,7 +305,7 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
     WidgetTester tester,
     ui.Image image,
     ByteData byteData,
-    ) async {
+  ) async {
     Evaluation result = const Evaluation.pass();
 
     // Skip disabled nodes, as they not required to pass contrast check.
@@ -345,7 +345,7 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
     WidgetTester tester,
     ui.Image image,
     ByteData byteData,
-    ) async {
+  ) async {
     // Look up inherited text properties to determine text size and weight.
     late bool isBold;
     double? fontSize;

--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -340,13 +340,12 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
   }
 
   Future<Evaluation> _evaluateElement(
-      SemanticsNode node,
-      Element element,
-      WidgetTester tester,
-      ui.Image image,
-      ByteData byteData,
-      ) async {
-    const Evaluation result = Evaluation.pass();
+    SemanticsNode node,
+    Element element,
+    WidgetTester tester,
+    ui.Image image,
+    ByteData byteData,
+    ) async {
     // Look up inherited text properties to determine text size and weight.
     late bool isBold;
     double? fontSize;
@@ -380,14 +379,14 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
     }
 
     if (isNodeOffScreen(paintBounds, tester.binding.window)) {
-      return result;
+      return const Evaluation.pass();
     }
 
     final Map<Color, int> colorHistogram = _colorsWithinRect(byteData, paintBounds, image.width, image.height);
 
     // Node was too far off screen.
     if (colorHistogram.isEmpty) {
-      return result;
+      return const Evaluation.pass();
     }
 
     final _ContrastReport report = _ContrastReport(colorHistogram);
@@ -396,19 +395,18 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
     final double targetContrastRatio = this.targetContrastRatio(fontSize, bold: isBold);
 
     if (contrastRatio - targetContrastRatio >= _tolerance) {
-      return result + const Evaluation.pass();
+      return const Evaluation.pass();
     }
-    return result +
-        Evaluation.fail(
-          '$node:\n'
-          'Expected contrast ratio of at least $targetContrastRatio '
-          'but found ${contrastRatio.toStringAsFixed(2)} '
-          'for a font size of $fontSize.\n'
-          'The computed colors was:\n'
-          'light - ${report.lightColor}, dark - ${report.darkColor}\n'
-          'See also: '
-          'https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html',
-        );
+    return Evaluation.fail(
+      '$node:\n'
+      'Expected contrast ratio of at least $targetContrastRatio '
+      'but found ${contrastRatio.toStringAsFixed(2)} '
+      'for a font size of $fontSize.\n'
+      'The computed colors was:\n'
+      'light - ${report.lightColor}, dark - ${report.darkColor}\n'
+      'See also: '
+      'https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html',
+    );
   }
 
   /// Returns whether node should be skipped.

--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -346,7 +346,7 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
       ui.Image image,
       ByteData byteData,
       ) async {
-    Evaluation result = const Evaluation.pass();
+    const Evaluation result = Evaluation.pass();
     // Look up inherited text properties to determine text size and weight.
     late bool isBold;
     double? fontSize;

--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -305,7 +305,7 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
     WidgetTester tester,
     ui.Image image,
     ByteData byteData,
-    ) async {
+  ) async {
     Evaluation result = const Evaluation.pass();
 
     // Skip disabled nodes, as they not required to pass contrast check.

--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -332,7 +332,7 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
       return result;
     }
     final String text = data.label.isEmpty ? data.value : data.label;
-    final List<Element> elements = find.text(text).hitTestable().evaluate().toList();
+    final Iterable<Element> elements = find.text(text).hitTestable().evaluate();
     for (final Element element in elements) {
       result += await _evaluateElement(node, element, tester, image, byteData);
     }

--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -331,6 +331,7 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
     if (shouldSkipNode(data)) {
       return result;
     }
+    final String text = data.label.isEmpty ? data.value : data.label;
     final List<Element> elements = find.text(text).hitTestable().evaluate().toList();
     for (final Element element in elements) {
       result += await _evaluateElement(node, element, tester, image, byteData);
@@ -350,7 +351,6 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
     late bool isBold;
     double? fontSize;
 
-    final String text = data.label.isEmpty ? data.value : data.label;
     late final Rect paintBounds;
 
     final RenderObject? renderBox = element.renderObject;

--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -371,8 +371,8 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
 
     final Offset? nodeOffset = node.transform != null ? MatrixUtils.getAsTranslation(node.transform!) : null;
 
-    Rect nodeBounds = node.rect.shift(nodeOffset ?? Offset.zero);
-    Rect intersection = nodeBounds.intersect(paintBounds);
+    final Rect nodeBounds = node.rect.shift(nodeOffset ?? Offset.zero);
+    final Rect intersection = nodeBounds.intersect(paintBounds);
     if (intersection.width <= 0 || intersection.height <= 0) {
       // Skip this element since it doesn't correspond to the given semantic
       // node.

--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -305,7 +305,7 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
     WidgetTester tester,
     ui.Image image,
     ByteData byteData,
-  ) async {
+    ) async {
     Evaluation result = const Evaluation.pass();
 
     // Skip disabled nodes, as they not required to pass contrast check.

--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -27,13 +27,13 @@ void main() {
       final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(
         _boilerplate(
-          const Column(
+          Column(
             children: [
-              Text(
+              const Text(
                 'this is a test',
                 style: TextStyle(fontSize: 14.0, color: Colors.black),
               ),
-              Text(
+              const Text(
                 'this is a test',
                 style: TextStyle(fontSize: 14.0, color: Colors.black),
               ),

--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -58,10 +58,12 @@ void main() {
                   'this is a test',
                   style: TextStyle(fontSize: 14.0, color: Colors.black),
                 ),
+                SizedBox(height: 50),
                 Text(
                   'this is a test',
                   style: TextStyle(fontSize: 14.0, color: Colors.black),
                 ),
+                SizedBox(height: 50),
                 ExcludeSemantics(
                   child: Text(
                     'this is a test',

--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -38,11 +38,42 @@ void main() {
                 style: TextStyle(fontSize: 14.0, color: Colors.black),
               ),
             ],
-          )
+          ),
         ),
       );
       await expectLater(tester, meetsGuideline(textContrastGuideline));
       handle.dispose();
+    });
+
+    testWidgets(
+      'Multiple text with same label but Nodes excluded from '
+      'semantic tree have failing contrast should pass a11y guideline ',
+      (WidgetTester tester) async {
+        final SemanticsHandle handle = tester.ensureSemantics();
+        await tester.pumpWidget(
+          _boilerplate(
+            Column(
+              children: const <Widget>[
+                Text(
+                  'this is a test',
+                  style: TextStyle(fontSize: 14.0, color: Colors.black),
+                ),
+                Text(
+                  'this is a test',
+                  style: TextStyle(fontSize: 14.0, color: Colors.black),
+                ),
+                ExcludeSemantics(
+                  child: Text(
+                    'this is a test',
+                    style: TextStyle(fontSize: 14.0, color: Colors.white),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+        await expectLater(tester, meetsGuideline(textContrastGuideline));
+        handle.dispose();
     });
 
     testWidgets('white text on black background - Text Widget - direct style',

--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -23,6 +23,28 @@ void main() {
       handle.dispose();
     });
 
+    testWidgets('Multiple text with same label', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        _boilerplate(
+          const Column(
+            children: [
+              Text(
+                'this is a test',
+                style: TextStyle(fontSize: 14.0, color: Colors.black),
+              ),
+              Text(
+                'this is a test',
+                style: TextStyle(fontSize: 14.0, color: Colors.black),
+              ),
+            ],
+          )
+        ),
+      );
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
     testWidgets('white text on black background - Text Widget - direct style',
         (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();

--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -28,7 +28,7 @@ void main() {
       await tester.pumpWidget(
         _boilerplate(
           Column(
-            children: const [
+            children: const <Widget>[
               Text(
                 'this is a test',
                 style: TextStyle(fontSize: 14.0, color: Colors.black),

--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -28,12 +28,12 @@ void main() {
       await tester.pumpWidget(
         _boilerplate(
           Column(
-            children: [
-              const Text(
+            children: const [
+              Text(
                 'this is a test',
                 style: TextStyle(fontSize: 14.0, color: Colors.black),
               ),
-              const Text(
+              Text(
                 'this is a test',
                 style: TextStyle(fontSize: 14.0, color: Colors.black),
               ),


### PR DESCRIPTION
Update the accessibility test to cover all Elements with same semantic label to get better coverage on contrast test.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
