### PR TITLE
Additional test

### DIFF
--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -45,6 +45,36 @@ void main() {
       handle.dispose();
     });
 
+    testWidgets('Multiple text with same label but Nodes excluded from '
+        'semantic tree have failing contrast should pass a11y guideline ',
+            (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        _boilerplate(
+            Column(
+              children: const <Widget>[
+                Text(
+                  'this is a test',
+                  style: TextStyle(fontSize: 14.0, color: Colors.black),
+                ),
+                Text(
+                  'this is a test',
+                  style: TextStyle(fontSize: 14.0, color: Colors.black),
+                ),
+                ExcludeSemantics(
+                  child: Text(
+                    'this is a test',
+                    style: TextStyle(fontSize: 14.0, color: Colors.white),
+                  ),
+                ),
+              ],
+            )
+        ),
+      );
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
     testWidgets('white text on black background - Text Widget - direct style',
         (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();

--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -68,7 +68,7 @@ void main() {
                   ),
                 ),
               ],
-            )
+            ),
         ),
       );
       await expectLater(tester, meetsGuideline(textContrastGuideline));

--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -74,7 +74,7 @@ void main() {
         );
         await expectLater(tester, meetsGuideline(textContrastGuideline));
         handle.dispose();
-      });
+    });
 
     testWidgets('white text on black background - Text Widget - direct style',
         (WidgetTester tester) async {

--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -38,19 +38,20 @@ void main() {
                 style: TextStyle(fontSize: 14.0, color: Colors.black),
               ),
             ],
-          )
+          ),
         ),
       );
       await expectLater(tester, meetsGuideline(textContrastGuideline));
       handle.dispose();
     });
 
-    testWidgets('Multiple text with same label but Nodes excluded from '
-        'semantic tree have failing contrast should pass a11y guideline ',
-            (WidgetTester tester) async {
-      final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(
-        _boilerplate(
+    testWidgets(
+      'Multiple text with same label but Nodes excluded from '
+      'semantic tree have failing contrast should pass a11y guideline ',
+      (WidgetTester tester) async {
+        final SemanticsHandle handle = tester.ensureSemantics();
+        await tester.pumpWidget(
+          _boilerplate(
             Column(
               children: const <Widget>[
                 Text(
@@ -69,11 +70,11 @@ void main() {
                 ),
               ],
             ),
-        ),
-      );
-      await expectLater(tester, meetsGuideline(textContrastGuideline));
-      handle.dispose();
-    });
+          ),
+        );
+        await expectLater(tester, meetsGuideline(textContrastGuideline));
+        handle.dispose();
+      });
 
     testWidgets('white text on black background - Text Widget - direct style',
         (WidgetTester tester) async {


### PR DESCRIPTION
Add a test with multiple nodes with same semantic label. but one of the label is excluded from semantic tree and has failing contrast (white on white) but this should pass a11y contrast test. 